### PR TITLE
General improvements for GM handling

### DIFF
--- a/include/mrf_problem_construction.hxx
+++ b/include/mrf_problem_construction.hxx
@@ -726,6 +726,12 @@ protected:
    std::map<std::array<INDEX,3>, INDEX> tripletMap_; // given two sorted indices, return factorId belonging to that index.
 };
 
+template<typename, typename = std::void_t<>>
+struct MrfHasTripletFactors : std::false_type { };
+
+template<typename T>
+struct MrfHasTripletFactors<T, std::void_t<typename T::TripletFactor>> : std::true_type { };
+
 
 ///////////////////////////////////////////////////////////////////
 //

--- a/include/mrf_problem_construction.hxx
+++ b/include/mrf_problem_construction.hxx
@@ -70,8 +70,8 @@ public:
       }
       unaryFactor_[node_number] = u;
    }
-   template<typename COST>
-   PairwiseFactorContainer* AddPairwiseFactor(INDEX var1, INDEX var2, const COST& cost)
+   template<typename... ARGS>
+   PairwiseFactorContainer* AddPairwiseFactor(INDEX var1, INDEX var2, ARGS... args)
    { 
       //if(var1 > var2) std::swap(var1,var2);
       assert(var1<var2);
@@ -79,7 +79,7 @@ public:
       //assert(cost.size() == GetNumberOfLabels(var1) * GetNumberOfLabels(var2));
       //assert(pairwiseMap_.find(std::make_tuple(var1,var2)) == pairwiseMap_.end());
       //PairwiseFactorContainer* p = new PairwiseFactorContainer(PairwiseFactor(cost), cost);
-      auto* p = new PairwiseFactorContainer(GetNumberOfLabels(var1), GetNumberOfLabels(var2), cost);
+      auto* p = new PairwiseFactorContainer(GetNumberOfLabels(var1), GetNumberOfLabels(var2), args...);
       lp_->AddFactor(p);
       ConstructPairwiseFactor(*(p->GetFactor()), var1, var2);
       pairwiseFactor_.push_back(p);


### PR DESCRIPTION
This PR handles two things:

- It allows to save (reparametrized) GMs in OpenGM container format (using ExplicitFunctions).
- Tweaks ProblemConstructor to match LP_MPs interface (only small inconsistency I recognized during writing temporary code).

Saving GMs is a bit complicated, as some models have TripletFactors and some have not. If you have better ideas than introducing a `MrfHasTripletFactors` trait, please let me know :)